### PR TITLE
Add filename and thumbTime to mux.videoAsset schema

### DIFF
--- a/src/schema/mux.videoAsset.js
+++ b/src/schema/mux.videoAsset.js
@@ -14,6 +14,14 @@ export default {
     {
       type: 'string',
       name: 'playbackId'
+    },
+    {
+      type: 'string',
+      name: 'filename'
+    },
+    {
+      type: 'number',
+      name: 'thumbTime'
     }
   ]
 }


### PR DESCRIPTION
GraphQL doesn't pick these up unless they are defined, at at least `thumbTime` is needed by `sanity-mux-player`