### PR TITLE
Add mp4 support

### DIFF
--- a/src/clients/upChunkObserable.js
+++ b/src/clients/upChunkObserable.js
@@ -6,7 +6,8 @@ export function createUpChunkObservable(uuid, uploadUrl, source) {
     const upchunk = UpChunk.createUpload({
       endpoint: uploadUrl,
       file: source,
-      chunkSize: 5120 // Uploads the file in ~5mb chunks
+      chunkSize: 5120, // Uploads the file in ~5mb chunks
+      mp4_support: 'standard'
     })
 
     const successHandler = () => {


### PR DESCRIPTION
Adds mp4 support and resolve [this issue](https://github.com/sanity-io/sanity-plugin-mux-input/issues/10). Needs to be confirmed that the Mux SDK supports [their new feature](https://docs.mux.com/docs/mp4-support).