### PR TITLE
[WIP - feedback please] Start adding mp4 support for mux uploads

### DIFF
--- a/src/schema/mux.videoAsset.js
+++ b/src/schema/mux.videoAsset.js
@@ -22,6 +22,19 @@ export default {
     {
       type: 'number',
       name: 'thumbTime'
+    },
+    {
+      type: 'string',
+      name: 'mp4Support'
+    },
+    {
+      type: 'string',
+      name: 'mp4SupportStatus'
+    },
+    {
+      type: 'array',
+      name: 'mp4Files',
+      of: [{type: 'string'}]
     }
   ]
 }


### PR DESCRIPTION
When assets are created in Mux, by default there is no mp4 access (we expect users to use the `playbackId` and stream over HLS.

However, there are valid cases for wanting mp4 support for assets, most commonly:

1. Offline access
1. Offer ability for end users to download the video

It was requested by a mutual customer to add this feature to the sanity-plugin-mux-input, so I got started here.

The Mux API supports adding mp4 support to assets in two ways (1) asset creation time OR (2) after the asset is created. A couple decisions to be made:

1. Automatically add mp4 support for all assets that are added through Sanity?
1. When creating an asset, a checkbox to toggle if mp4 support is added or not?
1. If (2), Allow an interface for users to add mp4 support to assets that have already been created through sanity?

The simplest answer is (1). But I'm not opposed to (2) or (2) and (3). Adding mp4 support doesn't have any extra cost to the user, but it does add storage cost that Mux has to pay for, so it might be in our best interest to *not* automatically add it by default.

Note that when mp4 support is added the asset object in Mux world looks like this (we call them static renditions). Mux will create up to 3 static renditions (mp4s) of an asset, depending on the quality of the source file. This is the line in our [docs](https://docs.mux.com/docs/mp4-support)

> Depending on the source video uploaded, you will have one or more options for MP4 renditions. If the source video had a low resolution (e.g. 240p) there will only be a `low.mp4` file available. If the source video had a high resolution (HD, 720p+) you will have three options: `low.mp4`, `medium.mp4`, and `high.mp4`.

```
"mp4_support": "standard",
"static_renditions": {
    "status": "ready",
    "files": [
      {
        "width": 640,
        "name": "low.mp4",
        "height": 360,
        "filesize": 1936492,
        "ext": "mp4",
        "bitrate": 649360
      },
      {
        "width": 960,
        "name": "medium.mp4",
        "height": 540,
        "filesize": 3293669,
        "ext": "mp4",
        "bitrate": 1104464
      },
      {
        "width": 1920,
        "name": "high.mp4",
        "height": 1080,
        "filesize": 9170933,
        "ext": "mp4",
        "bitrate": 3075296
      }
    ]
  },
```

Given this, I added some fields to the `mux.videoAsset` type in Sanity world, which would look something like this. I'm in no way married to this schema, I'm open to suggestions:

```
mp4Support: "standard",
mp4SupportStatus: "ready",
mp4Files: ["low.mp4", "medium.mp4", "high.mp4"]
```

-----

### Open questions/ things I need help on:

1. This code works when the user adds a url to a video (by adding `mp4_support: "standard"` to the request that eventually hits Mux's backend)
1. I tried adding `muxBody` as a query param to the request for files that are uploads, but it looks like that is not being passed through the same way the params are passed through when a URL is added.
1. I thought all the code that interacts with Mux lives in this plugin, but it looks like there is code running on sanity's backend that handles requests to Mux. Please correct me if I'm wrong, but I don't think it is in my power to make all the changes necessary to add this feature. - The client makes requests to `/addons/mux/` and then Sanity's backend eventually makes a request to Mux.
1. Right now, the observables on the client correctly wait for the asset to be `ready` - it appears that Sanity's backend is polling the Mux API, waiting for the asset status to be `ready`. With added mp4 support, we're going to have a small extra complication, because the `asset` and the `static_renditions` will each become `ready` at different times, so when Sanity polls the Mux API on the backend, it will have to wait for both parts to be ready.