### PR TITLE
implement focus() instance method to fix regression in 0.3.0

### DIFF
--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -124,6 +124,10 @@ export default withDocument(
       }
     }
 
+    focus = () => {
+      this.handleFocus();
+    }
+
     handleFocus = () => {
       this.setState({hasFocus: true})
     }

--- a/src/components/Setup.js
+++ b/src/components/Setup.js
@@ -105,6 +105,13 @@ class MuxVideoInputSetup extends Component {
 
     const hasValidSigningKeys = await haveValidSigningKeys(signingKeyId, signingKeyPrivate)
 
+    try {
+      await saveSecrets(token, secretKey, enableSignedUrls, signingKeyId, signingKeyPrivate)
+    } catch (err) {
+      handleError(err)
+      return
+    }
+
     if (!hasValidSigningKeys && enableSignedUrls) {
       try {
         const { data } = await createSigningKeys()
@@ -113,13 +120,6 @@ class MuxVideoInputSetup extends Component {
       } catch ({ message }) {
         this.setState({ error: message })
       }
-    }
-
-    try {
-      await saveSecrets(token, secretKey, enableSignedUrls, signingKeyId, signingKeyPrivate)
-    } catch (err) {
-      handleError(err)
-      return
     }
 
     let result


### PR DESCRIPTION
closes https://github.com/sanity-io/sanity-plugin-mux-input/issues/25

Also fix a bug when new users enable signing keys at the same time as saving API keys for the first time