### PR TITLE
Fix bug when enabling signed URLs from the start

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,17 @@ You could use any player which supports HLS, just point the video source to:
 To enable [signed urls](https://docs.mux.com/docs/security-signed-urls) with content uploaded to Mux, you will need to check the "Enable Signed Urls" option in the Mux Plugin configuration. Assuming that the API Access Token and Secret Key are set (as per the [Quick start](#quick-start) section).
 
 More information for this feature of the plugin can be found on Mux's [documentation](https://docs.mux.com/docs/headless-cms-sanity#advanced-signed-urls)
+
+# Contributing
+
+Issues are actively monitored and PRs are welcome. When developing this plugin the easiest setup is:
+
+1. Fork this repo.
+1. Install the sanity cli and create a sanity project: `npm install -g @sanity/cli && sanity init`. Follow the prompts, starting out with the blog template is a good way to go.
+1. `cd` into your project directory, run `npm install && npm start` - your sanity studio should be running on http://localhost:3333.
+1. `cd` into the `plugins` director of your project.
+1. Fork this repo and clone your fork into the `plugins` directory inside your project `git clone git@github.com:your-fork/sanity-plugin-mux-input.git`.
+1. Open `sanity.json`, go to the `plugins` array and add `mux-input`.
+1. Re-start the stanity studio server with `npm start`.
+1. Edit `schemas/post.js` and add follow the plugin documentation to add a `mux.video` type field.
+1. Your studio should reload, and now when you edit the plugin code it should reload the studio, when you're done create a branch, put in a PR and a maintainer will review it. Thank you!

--- a/README.md
+++ b/README.md
@@ -69,6 +69,6 @@ Issues are actively monitored and PRs are welcome. When developing this plugin t
 1. `cd` into the `plugins` director of your project.
 1. Fork this repo and clone your fork into the `plugins` directory inside your project `git clone git@github.com:your-fork/sanity-plugin-mux-input.git`.
 1. Open `sanity.json`, go to the `plugins` array and add `mux-input`.
-1. Re-start the stanity studio server with `npm start`.
+1. Re-start the sanity studio server with `npm start`.
 1. Edit `schemas/post.js` and add follow the plugin documentation to add a `mux.video` type field.
 1. Your studio should reload, and now when you edit the plugin code it should reload the studio, when you're done create a branch, put in a PR and a maintainer will review it. Thank you!

--- a/src/actions/secrets.js
+++ b/src/actions/secrets.js
@@ -71,13 +71,20 @@ export async function haveValidSigningKeys(signingKeyId, signingKeyPrivate) {
   }
 
   const dataset = client.clientConfig.dataset
-  const res = await client.request({
-    url: `/addons/mux/signing-keys/${dataset}/${signingKeyId}`,
-    withCredentials: true,
-    method: 'GET',
-  })
-
-  return res.status === 200
+  try {
+    const res = await client.request({
+      url: `/addons/mux/signing-keys/${dataset}/${signingKeyId}`,
+      withCredentials: true,
+      method: 'GET',
+    })
+    //
+    // if this signing key is valid it will return { data: { id: 'xxxx' } }
+    //
+    return !!(res.data && res.data.id);
+  } catch (e) {
+    console.error('Error fetching signingKeyId', signingKeyId, 'assuming it is not valid');
+    return false
+  }
 }
 
 export function testSecretsObservable() {

--- a/src/components/Setup.js
+++ b/src/components/Setup.js
@@ -117,6 +117,7 @@ class MuxVideoInputSetup extends Component {
         const { data } = await createSigningKeys()
         signingKeyId = data.id
         signingKeyPrivate = data.private_key
+        await saveSecrets(token, secretKey, enableSignedUrls, signingKeyId, signingKeyPrivate)
       } catch ({ message }) {
         this.setState({ error: message })
       }


### PR DESCRIPTION
2 bugs related to signed urls:

1. The studio could easily end up in a state of having `enableSignedUrls: true` and `signingKeyId: null, signingKeyPrivate: null` (introduced here: #26)
1. Every time the config modal was `saved` the plugin would re-generate signing keys. This is not a show-stopping bug, but it's certainly not ideal.

Also: updated README to include a note about setting up a development workflow. I found this to be the easiest workflow (`npm-link` wasn't working for me)

I took a stab at adding some automated tests with `jest`, but I got blocked around `sanity:part:` imports

```
 FAIL  src/components/Setup.test.js
  ● Test suite failed to run

    Cannot find module 'part:@sanity/base/client' from 'src/actions/secrets.js'
```

I tried executing the tests with `sanity exec` https://www.sanity.io/docs/cli, but that wasn't happy either because it was a plugin directory, not the project directory. And I didn't have jest installed in the *project*, so that was a little weird.

```
❯ yarn test --watch
yarn run v1.22.10
$ sanity exec jest --watch
Not in project directory, assuming context of project at /Users/dylanjhaveri/code/@muxinc/test-sanity-studio

Error: /Users/dylanjhaveri/code/@muxinc/test-sanity-studio/plugins/sanity-plugin-mux-input/jest does not exist
    at ~/code/@muxinc/test-sanity-studio/node_modules/@sanity/core/lib/actions/exec/execScript.js:53:13
    at Generator.next (<anonymous>)
    at asyncGeneratorStep (~/code/@muxinc/test-sanity-studio/node_modules/@sanity/core/lib/actions/exec/execScript.js:9:103)
    at _next (~/code/@muxinc/test-sanity-studio/node_modules/@sanity/core/lib/actions/exec/execScript.js:11:194)
error Command failed with exit code 1.
```

I would love to spend more time getting a testing harness set-up -- any tips there?