### PR TITLE
Storyboard and video deletion bugfixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-plugin-mux-input",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "description": "An input component that integrates Sanity Studio with Mux video encoding/hosting service.",
   "main": "build/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-plugin-mux-input",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.2-beta.0",
   "description": "An input component that integrates Sanity Studio with Mux video encoding/hosting service.",
   "main": "build/index.js",
   "scripts": {

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -694,9 +694,6 @@ export default withDocument(
                       mode="default"
                       tone="critical"
                       text="Remove"
-                      disabled={
-                        !this.state.deleteAssetDocumentChecked && !this.state.deleteOnMuxChecked
-                      }
                       onClick={this.handleRemoveVideo}
                       loading={!!isLoading}
                     />

--- a/src/util/getStoryboardSrc.js
+++ b/src/util/getStoryboardSrc.js
@@ -10,5 +10,5 @@ export default function getStoryboardSrc(playbackId, options = {}) {
     qs = `?token=${token}`
   }
 
-  return `https://image.mux.com/${playbackId}/storyboard.json?${qs}`
+  return `https://image.mux.com/${playbackId}/storyboard.vtt?${qs}`
 }


### PR DESCRIPTION
- Changed storyboard format to .vtt again back from .json
- Removed 'Remove' button disabled state as this caused videos to be unable to be removed unless either 'remove from mux' or 'remove from dataset' were checked.