### PR TITLE
feat: Adds opt-in support mp4 generation (refs #10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ To enable [signed urls](https://docs.mux.com/docs/security-signed-urls) with con
 
 More information for this feature of the plugin can be found on Mux's [documentation](https://docs.mux.com/docs/headless-cms-sanity#advanced-signed-urls)
 
+# Enabling MP4 support
+
+To enable [static MP4 renditions](https://docs.mux.com/guides/video/enable-static-mp4-renditions), create or open the config file found in `config/mux-input.json` in your studio folder. This file is automatically created the first time the studio starts after adding the plugin.
+
+```
+{
+  "mp4_support": "standard"
+}
+```
+
+Currently `mp4_support` is the only supported MUX option and this supports a value of either `standard` or `none` (the default).
+
 # Contributing
 
 Issues are actively monitored and PRs are welcome. When developing this plugin the easiest setup is:

--- a/config.dist.json
+++ b/config.dist.json
@@ -1,0 +1,3 @@
+{
+  "mp4_support": "none"
+}

--- a/src/components/Video.js
+++ b/src/components/Video.js
@@ -1,4 +1,4 @@
-import {Card, Stack, Text} from '@sanity/ui'
+import {Box, Card, Stack, Text} from '@sanity/ui'
 import Hls from 'hls.js'
 import 'media-chrome'
 import Button from 'part:@sanity/components/buttons/default'
@@ -37,6 +37,7 @@ class MuxVideo extends Component {
       isLoading: true,
       error: null,
       isDeletedOnMux: false,
+      isPreparingStaticRenditions: false,
       secrets: null,
     }
     this.playRef = React.createRef()
@@ -46,6 +47,7 @@ class MuxVideo extends Component {
   // eslint-disable-next-line complexity
   static getDerivedStateFromProps(nextProps) {
     let isLoading = true
+    let isPreparingStaticRenditions = false
     const {assetDocument} = nextProps
 
     if (assetDocument && assetDocument.status === 'preparing') {
@@ -63,7 +65,16 @@ class MuxVideo extends Component {
     if (assetDocument && typeof assetDocument.status === 'undefined') {
       isLoading = false
     }
-    return {isLoading}
+    if (assetDocument?.data?.static_renditions?.status === 'preparing') {
+      isPreparingStaticRenditions = true
+    }
+    if (assetDocument?.data?.static_renditions?.status === 'ready') {
+      isPreparingStaticRenditions = false
+    }
+    return {
+      isLoading,
+      isPreparingStaticRenditions,
+    }
   }
 
   componentDidMount() {
@@ -234,6 +245,7 @@ class MuxVideo extends Component {
               <track label="thumbnails" default kind="metadata" src={this.state.storyboardUrl} />
             )}
           </video>
+
           {showControls && (
             <media-control-bar>
               <media-play-button ref={this.playRef} />
@@ -250,6 +262,23 @@ class MuxVideo extends Component {
               <Text size={1}>There was an error loading this video ({error.type}).</Text>
               {this.state.isDeletedOnMux && <Text size={1}>The video is deleted on Mux</Text>}
             </Stack>
+          </Card>
+        )}
+
+        {this.state.isPreparingStaticRenditions && (
+          <Card
+            padding={2}
+            radius={1}
+            style={{
+              background: 'var(--card-fg-color)',
+              position: 'absolute',
+              top: '0.5em',
+              left: '0.5em',
+            }}
+          >
+            <Text size={1} style={{color: 'var(--card-bg-color)'}}>
+              MUX is preparing static renditions, please stand by
+            </Text>
           </Card>
         )}
       </div>

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,6 @@
+/* eslint-disable camelcase */
+import config from 'config:mux-input'
+
+export default {
+  mp4_support: config?.mp4_support || 'none',
+}


### PR DESCRIPTION
This builds upon the work done by @dylanjha in #13 – but I've just created this as a new PR as this has a different opinion on storing configuration (in a separate plugin json file) and also doesn't touch the `mux.videoAsset` document schema (as mp4-specific content is still accessible in the `data` object)

**Changes:**
- Expose a `mux-input.json` config file where users can opt-in to mp4 support. 
- Polling behaviour has been updated to listen for static renditions completed on MUX's end. When MP4 support is enabled: polling will continue until an asset has a ready status on the asset as well as nested static renditions
- If a user has opted in for MP4 support, a small badge / reminder is also displayed over the video input when static generation is still in progress. 

**Other comments:**
- Moving configuration into a plugin specific JSON file makes sense to me, not only is this a convention used across Sanity plugins, but also means we don't need to expose UI for them (as it's not _technically_ a secret unlike an API key). Other configuration – even enabling signed URLS – could also go here in future.

@dylanjha Would love your thoughts here