### PR TITLE
build: pin `@mux/upchunk` to v2.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",
   "dependencies": {
-    "@mux/upchunk": "^2.2.2",
+    "@mux/upchunk": "2.2.2",
     "@sanity/icons": "^1.2.1",
     "@sanity/ui": "^0.36.12",
     "@sanity/uuid": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1023,7 +1023,7 @@
   resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.3.1.tgz#b50a781709c81e10701004214340f25475a171a0"
   integrity sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw==
 
-"@mux/upchunk@^2.2.2":
+"@mux/upchunk@2.2.2":
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/@mux/upchunk/-/upchunk-2.2.2.tgz#52d629d435b50c32b2fed39566501a2210446805"
   integrity sha512-uaiQYdROFHM9LMasSJ0vDuwSv0nR/BxjkLOm11N2CIsynzz+Axfvy49Kg8r6Mq/DrRKsyrQP9z/Tl0LfAvX/aQ==


### PR DESCRIPTION
We’re currently seeing build issues when building Studios that depend on `sanity-plugin-mux-input`, seemingly caused by a recent update to `@mux/upchunk`.

This change pins the dependency to a version of `@mux/upchunk` that is known to work as expected.