### PR TITLE
Adding CMS tracking for Mux Data

### DIFF
--- a/src/components/Player.tsx
+++ b/src/components/Player.tsx
@@ -27,6 +27,7 @@ import {
   VideoContainer,
 } from './Player.styled'
 import {UploadProgress} from './UploadProgress'
+import pluginPkg from './../../package.json'
 
 interface Props extends Pick<MuxInputProps, 'onChange' | 'readOnly'> {
   buttons?: React.ReactNode
@@ -139,6 +140,11 @@ const MuxVideoOld = ({asset, buttons, readOnly, onChange, dialogState, setDialog
             slot="media"
             preload="metadata"
             crossOrigin="anonymous"
+            metadata={{
+              player_name: "Sanity Admin Dashboard",
+              player_version: pluginPkg.version,
+              page_type: "Preview Player",
+            }}
           >
             <ThumbnailsMetadataTrack asset={asset} />
           </MuxVideo>


### PR DESCRIPTION
This change adds metadata fields to the **Mux Data SDK** included within the `mux-video-react` element. This will allow us to aggregate usage across our CMS integrations. Mux Data fields that were populated are: `player_name`, `player_version`, & `page_type`.