### PR TITLE
fix: pin jsonwebtoken version to ^1.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@sanity/ui": "^1",
         "@sanity/uuid": "^3",
         "classnames": "^2.3.2",
-        "jsonwebtoken-esm": "^2.0.1",
+        "jsonwebtoken-esm": "^1.0.5",
         "media-chrome": "^0.18.8",
         "motion": "^10",
         "rxjs": "^7",
@@ -12423,9 +12423,9 @@
       }
     },
     "node_modules/jsonwebtoken-esm": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken-esm/-/jsonwebtoken-esm-2.0.1.tgz",
-      "integrity": "sha512-uZwq66J1WgwevzBheW8AMj8STn9QLXHLtY5cI52ztzip8VFPwoqaz/RQmgfNMivt+yD2Lfi4YS4uYHoKz0Fw9g==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken-esm/-/jsonwebtoken-esm-1.0.5.tgz",
+      "integrity": "sha512-CW3CJGtN3nAtkoyV58jl0aOo8VzFv3V2t24ef5OEdULwMGp9pUpnWkCmwxuwo16Tfhoq9cUBFLb3i9P2YlVc4Q==",
       "engines": {
         "node": ">=14.18"
       }
@@ -31926,9 +31926,9 @@
       }
     },
     "jsonwebtoken-esm": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken-esm/-/jsonwebtoken-esm-2.0.1.tgz",
-      "integrity": "sha512-uZwq66J1WgwevzBheW8AMj8STn9QLXHLtY5cI52ztzip8VFPwoqaz/RQmgfNMivt+yD2Lfi4YS4uYHoKz0Fw9g=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken-esm/-/jsonwebtoken-esm-1.0.5.tgz",
+      "integrity": "sha512-CW3CJGtN3nAtkoyV58jl0aOo8VzFv3V2t24ef5OEdULwMGp9pUpnWkCmwxuwo16Tfhoq9cUBFLb3i9P2YlVc4Q=="
     },
     "jsx-ast-utils": {
       "version": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@sanity/ui": "^1",
     "@sanity/uuid": "^3",
     "classnames": "^2.3.2",
-    "jsonwebtoken-esm": "^2.0.1",
+    "jsonwebtoken-esm": "^1.0.5",
     "media-chrome": "^0.18.8",
     "motion": "^10",
     "rxjs": "^7",


### PR DESCRIPTION
Fixes #239, #237, #224.

The root cause is that a PR from Renovate (#195) upgraded `jsonwebtoken-esm` to v2 which included a breaking change: https://github.com/sanity-io/jsonwebtoken-esm/releases/tag/v2.0.0

