### PR TITLE
Fix export declaration for node `import` to point at esm file

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
       "source": "./src/index.ts",
       "require": "./lib/index.cjs",
       "node": {
-        "import": "./lib/index.cjs.js",
+        "import": "./lib/index.js",
         "require": "./lib/index.cjs"
       },
       "import": "./lib/index.js",


### PR DESCRIPTION
fixes https://github.com/sanity-io/sanity-plugin-mux-input/issues/274
fixes https://github.com/sanity-io/sanity-plugin-mux-input/issues/252

When this plugin was being used in a next js project via ESM `import`s the package was unintentionally (I think?) pointing at the CommonJS entrypoint.  The change here updates `exports['.'].node.import` to match `exports['.'].import`.

I tested the fix using [a small repro project](https://github.com/streamify-com/sanity-next-mux) linked from the issues.  I updated the `sanity-plugin-mux-import` dependency to point at this repo on my local file system, and verified the bug with `npm install && npm run build`.  

After making this change + running `npm run build` on this branch, subsequent `npm run build` commands in the repro project did not hit this issue.