### PR TITLE
Remove mux-video-react prebundling

### DIFF
--- a/package.config.ts
+++ b/package.config.ts
@@ -1,8 +1,6 @@
 import {defineConfig} from '@sanity/pkg-utils'
 
 export default defineConfig({
-  // @TODO stop pre-bundling @mux/mux-video-react once this is fixed https://github.com/video-dev/hls.js/issues/5146
-  external: (externals) => externals.filter((e) => e !== '@mux/mux-video-react'),
   dist: 'lib',
   tsconfig: 'tsconfig.lib.json',
 


### PR DESCRIPTION
While working on fixing preview rendering, I saw that the linked issue in the TODO was fixed and released in hls.js v1.4.0.

This plugin is [currently on v1.4.1](https://github.com/sanity-io/sanity-plugin-mux-input/blob/145630221069d140025f62defe96dc27fb01b592/package-lock.json#L11640-L11641) so we should be able to remove this workaround now and better optimize dependency bundling and usage.