### PR TITLE
Add mux id in search and details

### DIFF
--- a/src/components/VideoDetails/VideoDetails.tsx
+++ b/src/components/VideoDetails/VideoDetails.tsx
@@ -8,6 +8,7 @@ import {
   RevertIcon,
   SearchIcon,
   TrashIcon,
+  TagIcon,
 } from '@sanity/icons'
 import {
   Button,
@@ -221,7 +222,12 @@ const VideoDetails: React.FC<VideoDetailsProps> = (props) => {
                 selected={tab === 'references'}
               />
             </TabList>
-            <TabPanel aria-labelledby="details-tab" id="details-panel" hidden={tab !== 'details'}>
+            <TabPanel
+              aria-labelledby="details-tab"
+              id="details-panel"
+              hidden={tab !== 'details'}
+              style={{wordBreak: 'break-word'}}
+            >
               <Stack space={4}>
                 <AssetInput
                   label="Video title or file name"
@@ -271,6 +277,7 @@ const VideoDetails: React.FC<VideoDetailsProps> = (props) => {
                     icon={CalendarIcon}
                     size={2}
                   />
+                  <IconInfo text={`Mux ID: \n${displayInfo.id}`} icon={TagIcon} size={2} />
                 </Stack>
               </Stack>
             </TabPanel>

--- a/src/components/VideoMetadata.tsx
+++ b/src/components/VideoMetadata.tsx
@@ -1,4 +1,4 @@
-import {CalendarIcon, ClockIcon} from '@sanity/icons'
+import {CalendarIcon, ClockIcon, TagIcon} from '@sanity/icons'
 import {Inline, Stack, Text} from '@sanity/ui'
 import React from 'react'
 
@@ -35,6 +35,9 @@ const VideoMetadata = (props: {asset: VideoAssetDocument}) => {
           size={1}
           muted
         />
+        {displayInfo.title != displayInfo.id.slice(0, 12) && (
+          <IconInfo text={displayInfo.id.slice(0, 12)} icon={TagIcon} size={1} muted />
+        )}
       </Inline>
     </Stack>
   )

--- a/src/util/getVideoMetadata.ts
+++ b/src/util/getVideoMetadata.ts
@@ -8,7 +8,8 @@ export default function getVideoMetadata(doc: VideoAssetDocument) {
     : new Date(doc._createdAt || doc._updatedAt || Date.now())
 
   return {
-    title: doc.filename || id.slice(0, 10),
+    title: doc.filename || id.slice(0, 12),
+    id: id,
     createdAt: date,
     duration: doc.data?.duration ? formatSeconds(doc.data?.duration) : undefined,
     aspect_ratio: doc.data?.aspect_ratio,


### PR DESCRIPTION
Enabled search mid word and show mux id tag if video has a custom name
![image](https://github.com/sanity-io/sanity-plugin-mux-input/assets/22635990/d9c50609-5ced-4c2b-b970-0610dc164794)
![image](https://github.com/sanity-io/sanity-plugin-mux-input/assets/22635990/70b36317-cd64-4b48-96b0-20db3febe827)

View full mux id in details:
![image](https://github.com/sanity-io/sanity-plugin-mux-input/assets/22635990/67fc4f38-adcf-4c86-aa48-c1b20e25f76b)


Allow search with id if the query is 8 or more characters.
This allows to search the video if you have the id, but won't show if you search for something short.
![image](https://github.com/sanity-io/sanity-plugin-mux-input/assets/22635990/fe21724f-2b78-4549-a4c5-78ab1f903cfb)
![image](https://github.com/sanity-io/sanity-plugin-mux-input/assets/22635990/453867d5-1bf7-4814-9a10-7c2195998bf0)
