### PR TITLE
fix: getplaybackpolicy to support multiple policies

### DIFF
--- a/src/util/getPlaybackPolicy.ts
+++ b/src/util/getPlaybackPolicy.ts
@@ -1,5 +1,10 @@
 import type {PlaybackPolicy, VideoAssetDocument} from './types'
 
-export function getPlaybackPolicy(asset: Pick<VideoAssetDocument, 'data'>): PlaybackPolicy {
-  return asset.data?.playback_ids?.[0]?.policy ?? 'public'
+export function getPlaybackPolicy(
+  asset: Pick<VideoAssetDocument, 'data' | 'playbackId'>
+): PlaybackPolicy {
+  return (
+    asset.data?.playback_ids?.find((playbackId) => asset.playbackId === playbackId.id)?.policy ??
+    'public'
+  )
 }


### PR DESCRIPTION
This PR rewrites the `getPlaybackPolicy` to use the policy from the `playbackId` in the root `VideoAssetDocument`. This due to the lack of video-previews and thumbnails showing when adding a signed policy using the plugin.

The changes in this PR is only a fix resolving the issue of not adding token to signed-urls for preview and thumbnail. Not the issue of two policies being created when selecting upload as signed-url " ref issue: https://github.com/sanity-io/sanity-plugin-mux-input/issues/367

## Reason for change
After adding a signed policy new assets will result in having two policies in mux (signed and public). The `playbackId` in the root of the asset looks to always be signed if selected. The `playbackIds`-array inside the `data` object will therefore include two ids and two policies, with public always being first element. However, the old implementation of `getPlaybackPolicy` only checks the first element in this array, resulting in the public policy and not the correct Id used for the video (using the top level id). The result of this is that the checks for the signed policy never pass and the tokens is not added to the urls --> no previews in sanity.

## Changes
Update the `getPlaybackPolicy` to get the correct policy from the `playbackId` located at the root of the asset-object. Still defaulting to `public`.

## Contributor
@skaugvoll