### PR TITLE
fix: prevent infinite loading issue on video browser

### DIFF
--- a/src/hooks/useAssets.ts
+++ b/src/hooks/useAssets.ts
@@ -47,18 +47,17 @@ export default function useAssets() {
 
   const assetDocumentsObservable = useAssetDocuments({documentStore, sort, searchQuery})
   const isLoading = assetDocumentsObservable === undefined
-  const assetDocuments = isLoading ? [] : assetDocumentsObservable
   const assets = useMemo(
     () =>
       // Avoid displaying both drafts & published assets by collating them together and giving preference to drafts
-      collate<VideoAssetDocument>(assetDocuments).map(
+      collate<VideoAssetDocument>(assetDocumentsObservable ?? []).map(
         (collated) =>
           ({
             ...(collated.draft || collated.published || {}),
             _id: collated.id,
           }) as VideoAssetDocument
       ),
-    [assetDocuments]
+    [assetDocumentsObservable]
   )
 
   return {

--- a/src/hooks/useAssets.ts
+++ b/src/hooks/useAssets.ts
@@ -1,5 +1,6 @@
 import {useMemo, useState} from 'react'
-import {collate, createHookFromObservableFactory, DocumentStore, useDocumentStore} from 'sanity'
+import {useObservable} from 'react-rx'
+import {collate, DocumentStore, useDocumentStore} from 'sanity'
 
 import {SANITY_API_VERSION} from '../hooks/useClient'
 import {createSearchFilter} from '../util/createSearchFilter'
@@ -14,33 +15,39 @@ export const ASSET_SORT_OPTIONS = {
 
 export type SortOption = keyof typeof ASSET_SORT_OPTIONS
 
-const useAssetDocuments = createHookFromObservableFactory<
-  VideoAssetDocument[],
-  {
-    documentStore: DocumentStore
-    sort: SortOption
-    searchQuery: string
-  }
->(({documentStore, sort, searchQuery}) => {
-  const search = createSearchFilter(searchQuery)
-  const filter = [`_type == "mux.videoAsset"`, ...search.filter].filter(Boolean).join(' && ')
+const useAssetDocuments = ({
+  documentStore,
+  sort,
+  searchQuery,
+}: {
+  documentStore: DocumentStore
+  sort: SortOption
+  searchQuery: string
+}): VideoAssetDocument[] | undefined => {
+  const memoizedObservable = useMemo(() => {
+    const search = createSearchFilter(searchQuery)
+    const filter = [`_type == "mux.videoAsset"`, ...search.filter].filter(Boolean).join(' && ')
+    const sortFragment = ASSET_SORT_OPTIONS[sort].groq
+    return documentStore.listenQuery(
+      /* groq */ `*[${filter}] | order(${sortFragment})`,
+      search.params,
+      {
+        apiVersion: SANITY_API_VERSION,
+      }
+    )
+  }, [documentStore, sort, searchQuery])
 
-  const sortFragment = ASSET_SORT_OPTIONS[sort].groq
-  return documentStore.listenQuery(
-    /* groq */ `*[${filter}] | order(${sortFragment})`,
-    search.params,
-    {
-      apiVersion: SANITY_API_VERSION,
-    }
-  )
-})
+  return useObservable(memoizedObservable, undefined)
+}
 
 export default function useAssets() {
   const documentStore = useDocumentStore()
   const [sort, setSort] = useState<SortOption>('createdDesc')
   const [searchQuery, setSearchQuery] = useState('')
 
-  const [assetDocuments = [], isLoading] = useAssetDocuments({documentStore, sort, searchQuery})
+  const assetDocumentsObservable = useAssetDocuments({documentStore, sort, searchQuery})
+  const isLoading = assetDocumentsObservable === undefined
+  const assetDocuments = isLoading ? [] : assetDocumentsObservable
   const assets = useMemo(
     () =>
       // Avoid displaying both drafts & published assets by collating them together and giving preference to drafts


### PR DESCRIPTION
This PR updates `useAssets.ts` by replacing the use of `createHookFromObservableFactory` with a memoized observable. This change addresses an incompatibility with recent versions of Sanity that caused infinite loading in the VideoBrowser, resulting in a broken user experience and potentially high costs due to the excessive number of requests made to Sanity. Fixes #397.

As this is my first contribution to this project—and to the Sanity ecosystem in general—I’d greatly appreciate a detailed review. I've based this code on the example in https://www.sanity.io/docs/studio-react-hooks#7a5503c777f4 but I’m open to any suggestions for improving this approach or aligning with standard practices for handling observables. Thank you for your time and feedback!