### PR TITLE
feat: Improve Error Messaging for Signed URLs Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ export default function MuxVideo({playbackId, title}: {playbackId?: string; titl
 
 To enable [signed URLs](https://docs.mux.com/docs/security-signed-urls) with content uploaded to Mux, you will need to check the "Enable Signed Urls" option in the Mux Plugin configuration. This feature requires you to set the API Access Token and Secret Key (as per the [Quick start](#quick-start) section).
 
+⚠️ **Important:** To use Signed URLs, the API Access Token must have **System permissions**. Without these permissions, the signing key cannot be created, and authentication will fail.
+
 📌 **Note**: When the signed URL option is triggered, the plugin will cache a `signingKeyPrivate` in a private document in the dataset. This key is used by Mux to sign the uploads, and if it's incorrect your uploads will fail. If that's the case, you can delete the secrets document and try again:
 
 ```bash

--- a/src/actions/secrets.ts
+++ b/src/actions/secrets.ts
@@ -32,15 +32,25 @@ export function saveSecrets(
   return client.createOrReplace(doc)
 }
 
-export function createSigningKeys(client: SanityClient) {
-  const {dataset} = client.config()
-  return client.request<{
-    data: {private_key: string; id: string; created_at: string}
-  }>({
-    url: `/addons/mux/signing-keys/${dataset}`,
-    withCredentials: true,
-    method: 'POST',
-  })
+export async function createSigningKeys(client: SanityClient) {
+  try {
+    const {dataset} = client.config()
+    const res = await client.request<{
+      data: {private_key: string; id: string; created_at: string}
+    }>({
+      url: `/addons/mux/signing-keys/${dataset}`,
+      withCredentials: true,
+      method: 'POST',
+    })
+    return res
+  } catch (error: any) {
+    console.error('Error creating signing keys', error)
+    const message =
+      error.response?.statusCode === 401
+        ? 'Unauthorized - Failed to create the Signing Key. Please ensure that the token has "System" permissions'
+        : error.message
+    throw new Error(message)
+  }
 }
 
 export function testSecrets(client: SanityClient) {

--- a/src/components/ConfigureApi.tsx
+++ b/src/components/ConfigureApi.tsx
@@ -139,6 +139,8 @@ function ConfigureApi({secrets, setDialogState}: Props) {
                     The access token needs permissions: <strong>Mux Video </strong>
                     (Full Access) and <strong>Mux Data</strong> (Read)
                     <br />
+                    To use Signed URLs, the token must also have System permissions.
+                    <br />
                     The credentials will be stored safely in a hidden document only available to
                     editors.
                   </Text>


### PR DESCRIPTION
Related to #360 
When attempting to configure an API token with the Signed URLs option enabled, if an error occurs, the returned message is unclear. This can make it difficult to understand why the setup is failing.

## Changes
- Improving the informational message shown when configuring API credentials to provide better guidance.
- Displaying a clearer error message when the API token lacks the necessary System permissions.
- Updating the README.md to explicitly state that System permissions are required for Signed URLs.

## Screenshots
![image](https://github.com/user-attachments/assets/2b7c2da0-a6c5-4ea2-9a77-3156f2d45f36)
![image (1)](https://github.com/user-attachments/assets/7afcd61b-63db-4dfa-ab43-1e3dfad36498)
