### PR TITLE
fix: infinite loading issue in used by section of video details

### DIFF
--- a/src/components/VideoDetails/useVideoDetails.ts
+++ b/src/components/VideoDetails/useVideoDetails.ts
@@ -1,5 +1,5 @@
 import {useToast} from '@sanity/ui'
-import {useState} from 'react'
+import {useMemo, useState} from 'react'
 import {useDocumentStore} from 'sanity'
 
 import {useClient} from '../../hooks/useClient'
@@ -17,10 +17,10 @@ export default function useVideoDetails(props: VideoDetailsProps) {
   const documentStore = useDocumentStore()
   const toast = useToast()
   const client = useClient()
-  const [references, referencesLoading] = useDocReferences({
-    documentStore,
-    id: props.asset._id as string,
-  })
+
+  const [references, referencesLoading] = useDocReferences(
+    useMemo(() => ({documentStore, id: props.asset._id}), [documentStore, props.asset._id])
+  )
 
   const [originalAsset, setOriginalAsset] = useState(() => props.asset)
   const [filename, setFilename] = useState(props.asset.filename)


### PR DESCRIPTION
Fixes #408

In Sanity v3.68.0, the `createHookFromObservableFactory` function was refactored to remove the `useUnique` hook: [#b1f183d](https://github.com/sanity-io/sanity/commit/b1f183db1c4f206aa96d8cf5a196f10d8b2f03a6#diff-830ce31bc0c9f327f85a4f1753ab3c4ac9640733a67a82479d7c24c77d3a800aL6). This caused infinite loading in the hooks created from this function in this plugin, leading to excessive API requests.

This PR resolves the infinite loading issue by memoizing the arguments passed to the hooks. Additionally, I’ve refactored the `useAssets` hook (updated in [this PR](https://github.com/sanity-io/sanity-plugin-mux-input/pull/399)) to once again use `createHookFromObservableFactory` for consistency.

I am open to suggestions and appreciate any feedback