### PR TITLE
feat: mark mux.videoAsset as document type

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -141,7 +141,7 @@ const muxAssetData = {
 
 const muxVideoAsset = {
   name: 'mux.videoAsset',
-  type: 'object',
+  type: 'document',
   title: 'Video asset',
   fields: [
     {


### PR DESCRIPTION
Since the `mux.videoAsset` is marked as an inline object instead of a `document` typegen aren't able to dereference the asset.

This fixes https://github.com/sanity-io/sanity-plugin-mux-input/issues/371

Fix demonstrated here: https://github.com/sanity-io/sanity-plugin-mux-input/pull/413