### PR TITLE
fix: broken sanity schema extract

### DIFF
--- a/src/components/VideoDetails/DeleteDialog.tsx
+++ b/src/components/VideoDetails/DeleteDialog.tsx
@@ -6,7 +6,7 @@ import type {SanityDocument} from 'sanity'
 import {deleteAsset} from '../../actions/assets'
 import {useClient} from '../../hooks/useClient'
 import {DIALOGS_Z_INDEX} from '../../util/constants'
-import type {PluginPlacement, VideoAssetDocument} from '../../util/types'
+import type {VideoAssetDocument} from '../../util/types'
 import SpinnerBox from '../SpinnerBox'
 import VideoReferences from './VideoReferences'
 
@@ -15,11 +15,9 @@ export default function DeleteDialog({
   references,
   referencesLoading,
   cancelDelete,
-  placement,
   succeededDeleting,
 }: {
   asset: VideoAssetDocument
-  placement: PluginPlacement
   references?: SanityDocument[]
   referencesLoading: boolean
   cancelDelete: () => void
@@ -95,11 +93,7 @@ export default function DeleteDialog({
                 pointing to this video. Remove their references to this file or delete them before
                 proceeding.
               </Text>
-              <VideoReferences
-                references={references}
-                isLoaded={!referencesLoading}
-                placement={placement}
-              />
+              <VideoReferences references={references} isLoaded={!referencesLoading} />
             </>
           )}
           {state === 'confirm' && (

--- a/src/components/VideoDetails/VideoDetails.tsx
+++ b/src/components/VideoDetails/VideoDetails.tsx
@@ -127,7 +127,6 @@ const VideoDetails: React.FC<VideoDetailsProps> = (props) => {
         <DeleteDialog
           asset={props.asset}
           cancelDelete={() => setState('idle')}
-          placement={props.placement}
           referencesLoading={referencesLoading}
           references={references}
           succeededDeleting={() => {
@@ -295,11 +294,7 @@ const VideoDetails: React.FC<VideoDetailsProps> = (props) => {
               id="references-panel"
               hidden={tab !== 'references'}
             >
-              <VideoReferences
-                references={references}
-                isLoaded={!referencesLoading}
-                placement={props.placement}
-              />
+              <VideoReferences references={references} isLoaded={!referencesLoading} />
             </TabPanel>
           </Stack>
         </Flex>

--- a/src/components/VideoDetails/VideoReferences.tsx
+++ b/src/components/VideoDetails/VideoReferences.tsx
@@ -3,7 +3,6 @@ import {Box, Card, Text} from '@sanity/ui'
 import {collate, useSchema} from 'sanity'
 import {styled} from 'styled-components'
 
-import type {PluginPlacement} from '../../util/types'
 import {DocumentPreview} from '../documentPreview/DocumentPreview'
 import SpinnerBox from '../SpinnerBox'
 
@@ -22,7 +21,6 @@ const Container = styled(Box)`
 const VideoReferences: React.FC<{
   references?: SanityDocument[]
   isLoaded: boolean
-  placement: PluginPlacement
 }> = (props) => {
   const schema = useSchema()
   if (!props.isLoaded) {
@@ -53,11 +51,7 @@ const VideoReferences: React.FC<{
             style={{overflow: 'hidden'}}
           >
             <Box>
-              <DocumentPreview
-                documentPair={documentPair}
-                schemaType={schemaType}
-                placement={props.placement}
-              />
+              <DocumentPreview documentPair={documentPair} schemaType={schemaType} />
             </Box>
           </Card>
         )

--- a/src/components/VideoDetails/useVideoDetails.ts
+++ b/src/components/VideoDetails/useVideoDetails.ts
@@ -5,10 +5,9 @@ import {useDocumentStore} from 'sanity'
 import {useClient} from '../../hooks/useClient'
 import useDocReferences from '../../hooks/useDocReferences'
 import getVideoMetadata from '../../util/getVideoMetadata'
-import {PluginPlacement, VideoAssetDocument} from '../../util/types'
+import {VideoAssetDocument} from '../../util/types'
 
 export interface VideoDetailsProps {
-  placement: PluginPlacement
   closeDialog: () => void
   asset: VideoAssetDocument & {autoPlay?: boolean}
 }

--- a/src/components/VideosBrowser.tsx
+++ b/src/components/VideosBrowser.tsx
@@ -75,11 +75,7 @@ export default function VideosBrowser({onSelect}: VideosBrowserProps) {
         )}
       </Stack>
       {freshEditedAsset && (
-        <VideoDetails
-          closeDialog={() => setEditedAsset(null)}
-          asset={freshEditedAsset}
-          placement={placement}
-        />
+        <VideoDetails closeDialog={() => setEditedAsset(null)} asset={freshEditedAsset} />
       )}
     </>
   )

--- a/src/components/documentPreview/DocumentPreview.tsx
+++ b/src/components/documentPreview/DocumentPreview.tsx
@@ -3,20 +3,16 @@
 import {DocumentIcon} from '@sanity/icons'
 import type {PropsWithChildren} from 'react'
 import React, {useMemo} from 'react'
-import type {SanityDocument} from 'sanity'
-import type {CollatedHit, FIXME, SchemaType} from 'sanity'
+import type {CollatedHit, FIXME, SanityDocument, SchemaType} from 'sanity'
 import {PreviewCard, useDocumentPresence, useDocumentPreviewStore, useSchema} from 'sanity'
-import {usePaneRouter} from 'sanity/desk'
 import {IntentLink} from 'sanity/router'
 
-import {PluginPlacement} from '../../util/types'
 import {MissingSchemaType} from './MissingSchemaType'
 import {PaneItemPreview} from './PaneItemPreview'
 
 interface DocumentPreviewProps {
   schemaType?: SchemaType
   documentPair: CollatedHit<SanityDocument>
-  placement?: PluginPlacement
 }
 
 /**
@@ -35,23 +31,7 @@ export function getIconWithFallback(
   return icon || ((schemaType && schemaType.icon) as any) || defaultIcon || false
 }
 
-/** When inside the field input, we can open the reference on a child pane */
-function DocumentPreviewInInput(props: PropsWithChildren<DocumentPreviewProps>) {
-  const {ChildLink} = usePaneRouter()
-
-  return (linkProps: PropsWithChildren) => (
-    <ChildLink
-      childId={props.documentPair.id}
-      // Pass the schemaType of the document so `paneChild` in `buildPagesStructure` can access it
-      childParameters={{type: props.documentPair.type}}
-    >
-      {linkProps.children}
-    </ChildLink>
-  )
-}
-
-/** When inside the tool, we must use a regular intent link to take users to the desk tool */
-function DocumentPreviewInRool(props: DocumentPreviewProps) {
+function DocumentPreviewLink(props: DocumentPreviewProps) {
   return (linkProps: PropsWithChildren) => (
     <IntentLink intent="edit" params={{id: props.documentPair.id}}>
       {linkProps.children}
@@ -90,11 +70,7 @@ export function DocumentPreview(props: DocumentPreviewProps) {
   return (
     <PreviewCard
       __unstable_focusRing
-      as={
-        (props.placement === 'input'
-          ? DocumentPreviewInInput(props)
-          : DocumentPreviewInRool(props)) as FIXME
-      }
+      as={DocumentPreviewLink(props) as FIXME}
       data-as="a"
       data-ui="PaneItem"
       padding={2}


### PR DESCRIPTION
Currently `sanity-plugin-mux-input` breaks schema extraction when running the `sanity schema extract` cli command. This is due to the usage of a deprecated hook `usePaneRouter` that comes from `sanity/desk`. This PR removes the usage of the deprecated hook within the `DocumentPreview` component and replaces it with an `IntentLink`. 

In addition to this I was also able to remove the `placement` prop from a number of components as they were only used to pass the placement value down through the component tree to the `DocumentPreview` component.