### PR TITLE
fix: Show configuration when allowedRolesForConfiguration is not set

### DIFF
--- a/src/hooks/useAccessControl.ts
+++ b/src/hooks/useAccessControl.ts
@@ -5,7 +5,7 @@ export const useAccessControl = (config: PluginConfig) => {
   const user = useCurrentUser()
 
   const hasConfigAccess =
-    !config?.allowedRolesForConfiguration ||
+    !config?.allowedRolesForConfiguration?.length ||
     user?.roles?.some((role) => config.allowedRolesForConfiguration.includes(role.name))
 
   return {hasConfigAccess}


### PR DESCRIPTION
Fixes #423 
Related to #401 

### Description

It solves an issue when the `allowedRolesForConfiguration` is not being set. 

### Testing

1. Create a new document which uses the Mux Video plugin.
2. Set the `allowedRolesForConfiguration` array to empty (this is already set by default).
3. You should see the configuration options.
