### PR TITLE
(fix): fixes no prompt for credentials if allowedRolesForConfiguration is not set

### DIFF
--- a/src/hooks/useAccessControl.ts
+++ b/src/hooks/useAccessControl.ts
@@ -5,7 +5,8 @@ export const useAccessControl = (config: PluginConfig) => {
   const user = useCurrentUser()
 
   const hasConfigAccess =
-    !config?.allowedRolesForConfiguration ||
+    config?.allowedRolesForConfiguration === undefined ||
+    config.allowedRolesForConfiguration.length === 0 ||
     user?.roles?.some((role) => config.allowedRolesForConfiguration.includes(role.name))
 
   return {hasConfigAccess}


### PR DESCRIPTION


### Description

Fixes the error presented in issue https://github.com/sanity-io/sanity-plugin-mux-input/issues/423

### What to review

Verify that projects can configure API credentials if `allowedRolesForConfiguration` is not provided. And if it is set, only allowed roles should be allowed to configure.


