### PR TITLE
fix: allow 0 as a valid time value for poster thumbnails

### DIFF
--- a/src/util/getPosterSrc.ts
+++ b/src/util/getPosterSrc.ts
@@ -18,7 +18,7 @@ export function getPosterSrc({
   width,
 }: PosterSrcOptions): MuxThumbnailUrl {
   const params = {fit_mode, height, width}
-  if (time) {
+  if (time !== undefined) {
     ;(params as any).time = time
   }
 


### PR DESCRIPTION
Previously, passing `time = 0` (intending to fetch the first frame of the video) was ignored because the code used a truthy check (`if (time)`). Since `0` is falsy in JavaScript, the `time` param was not included in the request, causing Mux to fall back to its default thumbnail time.

This commit updates the condition to check explicitly for `undefined` instead of falsiness. As a result, `0` is now correctly passed through as a valid value, while `undefined` continues to omit the `time` parameter.

### Description

Previously, passing `time = 0` (intending to fetch the first frame of the video) was ignored because the code used a truthy check (`if (time)`). Since `0` is falsy in JavaScript, the `time` param was not included in the request, causing Mux to fall back to its default thumbnail time.

This commit updates the condition to check explicitly for `undefined` instead of falsiness. As a result, `0` is now correctly passed through as a valid value, while `undefined` continues to omit the `time` parameter.