### PR TITLE
feat: Added `defaultPublic` configuration

### DIFF
--- a/src/_exports/index.ts
+++ b/src/_exports/index.ts
@@ -11,6 +11,7 @@ export const defaultConfig: PluginConfig = {
   encoding_tier: 'smart',
   max_resolution_tier: '1080p',
   normalize_audio: false,
+  defaultPublic: true,
   defaultSigned: false,
   tool: DEFAULT_TOOL_CONFIG,
   allowedRolesForConfiguration: [],

--- a/src/components/UploadConfiguration.tsx
+++ b/src/components/UploadConfiguration.tsx
@@ -142,7 +142,7 @@ export default function UploadConfiguration({
       max_resolution_tier: pluginConfig.max_resolution_tier,
       mp4_support: pluginConfig.mp4_support,
       signed_policy: secrets.enableSignedUrls && pluginConfig.defaultSigned,
-      public_policy: true,
+      public_policy: pluginConfig.defaultPublic,
       normalize_audio: pluginConfig.normalize_audio,
       text_tracks: autoTextTracks,
     } as UploadConfig

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -40,6 +40,12 @@ export interface MuxInputConfig {
   defaultSigned?: boolean
 
   /**
+   * Enables public URLs by default.
+   * @defaultValue true
+   */
+  defaultPublic?: boolean
+
+  /**
    * Auto-generate captions for these languages by default.
    * Requires `"encoding_tier": "smart"`
    *


### PR DESCRIPTION
### Description

Closes https://github.com/sanity-io/sanity-plugin-mux-input/issues/433

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR adds `defaultPublic` as an option for plugin configuration. This option reflects the default value for the "Public" checkbox in the "Advanced Playback Policies" when uploading an asset. It defaults to true.

Together with `defaultSigned` you can get the following configuration to force signed videos. For example this plugin configuration `muxInput({defaultPublic: false, defaultSigned: true})`.

<img width="666" height="736" alt="image" src="https://github.com/user-attachments/assets/3df51812-13fb-4392-afe7-ee216d25f585" />

<!--
### What to review

What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

<!--
### Testing

Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
