### PR TITLE
Upgraded Mux Player to 3.8.0 to fix issues with native chrome

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -8,7 +8,7 @@
       "name": "sanity-plugin-mux-input-example",
       "version": "0.1.0",
       "dependencies": {
-        "@mux/mux-player-react": "^2.6.0",
+        "@mux/mux-player-react": "^3.8.0",
         "@portabletext/react": "^3.0.18",
         "@sanity/client": "^6.27.2",
         "@sanity/image-url": "^1.0.2",
@@ -2759,31 +2759,41 @@
         "resolve": "~1.22.2"
       }
     },
-    "node_modules/@mux/mux-player": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-2.9.1.tgz",
-      "integrity": "sha512-TAyoUSPTV0IXWGMOknL6O+IeGSEJ8aS154DzyzqZgdd3zDJHM8JpkyNHgtowatMHT2lB6h+qMtWfp4u3ijpo2A==",
+    "node_modules/@mux/mux-data-google-ima": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@mux/mux-data-google-ima/-/mux-data-google-ima-0.2.8.tgz",
+      "integrity": "sha512-0ZEkHdcZ6bS8QtcjFcoJeZxJTpX7qRIledf4q1trMWPznugvtajCjCM2kieK/pzkZj1JM6liDRFs1PJSfVUs2A==",
       "license": "MIT",
       "dependencies": {
-        "@mux/mux-video": "0.20.2",
-        "@mux/playback-core": "0.25.2",
-        "media-chrome": "~3.2.5"
+        "mux-embed": "5.9.0"
+      }
+    },
+    "node_modules/@mux/mux-player": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-3.8.0.tgz",
+      "integrity": "sha512-2KcJdW4BBX8JDcXpclFKaNBsqpebtaEfTzwm5lPP1Lf6y5OMILvf2tqVCOczurREVFyaEoVD71vL0I5Vvqb1dA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mux/mux-video": "0.27.2",
+        "@mux/playback-core": "0.31.2",
+        "media-chrome": "~4.15.1",
+        "player.style": "^0.3.0"
       }
     },
     "node_modules/@mux/mux-player-react": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-2.9.1.tgz",
-      "integrity": "sha512-1BpMs1J7P+d+/QCf9/mkTk/NPYR6sOskR4Ih0uFZjDAqNUN7/C9Q0FEJ6hF3sFXwAXo50RhnfCzsC5uYx3QHbA==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-3.8.0.tgz",
+      "integrity": "sha512-c9TKtK9nsSpXOuC1LVLmmHA+Zlpcx4mzgGaA7ZlukrGMfoXWvA90ROSVAAjXRA+UKSHdLIbvNofgG3P6rEE/4Q==",
       "license": "MIT",
       "dependencies": {
-        "@mux/mux-player": "2.9.1",
-        "@mux/playback-core": "0.25.2",
-        "prop-types": "^15.7.2"
+        "@mux/mux-player": "3.8.0",
+        "@mux/playback-core": "0.31.2",
+        "prop-types": "^15.8.1"
       },
       "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18 || ^19",
-        "react": "^17.0.2 || ^18 || ^19",
-        "react-dom": "^17.0.2 || ^18 || ^19"
+        "@types/react": "^17.0.0 || ^17.0.0-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0",
+        "react": "^17.0.2 || ^17.0.0-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0",
+        "react-dom": "^17.0.2 || ^17.0.2-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -2795,25 +2805,26 @@
       }
     },
     "node_modules/@mux/mux-video": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.20.2.tgz",
-      "integrity": "sha512-CqkK9EZZWdQE4U62JKlmWDskirT+D9C4suh2tSqKb2CA/0S4ybbbrVWcCKF7xfadUacfKO1yPsOKbe46F6phVQ==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.27.2.tgz",
+      "integrity": "sha512-VAqSw/3kS/qBzjyFSX3wClIX5Kdk6eXXlhxIJRWlClYvUKGm9ruhd7HzkwZVOJguvUh5QbGoiGWBEW2xkNIXzw==",
       "license": "MIT",
       "dependencies": {
-        "@mux/playback-core": "0.25.2",
-        "castable-video": "~1.0.9",
-        "custom-media-element": "~1.3.1",
-        "media-tracks": "~0.3.2"
+        "@mux/mux-data-google-ima": "0.2.8",
+        "@mux/playback-core": "0.31.2",
+        "castable-video": "~1.1.11",
+        "custom-media-element": "~1.4.5",
+        "media-tracks": "~0.3.3"
       }
     },
     "node_modules/@mux/playback-core": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.25.2.tgz",
-      "integrity": "sha512-vrBbCgLHwmPpVxF0QGj+sXHUVXSxgDJJhVm8pxPXEkbw0vjPNHTXgAd/Ty6JA0vZ0ZjoQuAa17AxJ+c02JYeWQ==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.31.2.tgz",
+      "integrity": "sha512-bhOVTGAuKCQuDzNOc3XvDq7vsgqy2DAacLP0WdJciUKjfZhs3oA11NbKG7qAN6akPnZVfgn0Jn/sJN8TRjE30A==",
       "license": "MIT",
       "dependencies": {
-        "hls.js": "~1.5.11",
-        "mux-embed": "~5.2.0"
+        "hls.js": "~1.6.13",
+        "mux-embed": "^5.8.3"
       }
     },
     "node_modules/@mux/upchunk": {
@@ -6571,12 +6582,21 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/castable-video": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/castable-video/-/castable-video-1.0.10.tgz",
-      "integrity": "sha512-tJgUv+8/zE191y8EKojvB0eKIyKA9obIttd6Wpdm6x2qBmuwZ7wDgzVCSmf5cN2v9jBiuu0s7O5poz8a8cFX/w==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/castable-video/-/castable-video-1.1.11.tgz",
+      "integrity": "sha512-LCRTK6oe7SB1SiUQFzZCo6D6gcEzijqBTVIuj3smKpQdesXM18QTbCVqWgh9MfOeQgTx/i9ji5jGcdqNPeWg2g==",
       "license": "MIT",
       "dependencies": {
-        "custom-media-element": "~1.3.2"
+        "custom-media-element": "~1.4.5"
+      }
+    },
+    "node_modules/ce-la-react": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/ce-la-react/-/ce-la-react-0.3.1.tgz",
+      "integrity": "sha512-g0YwpZDPIwTwFumGTzNHcgJA6VhFfFCJkSNdUdC04br2UfU+56JDrJrJva3FZ7MToB4NDHAFBiPE/PZdNl1mQA==",
+      "license": "BSD-3-Clause",
+      "peerDependencies": {
+        "react": ">=17.0.0"
       }
     },
     "node_modules/chalk": {
@@ -7157,9 +7177,9 @@
       "license": "MIT"
     },
     "node_modules/custom-media-element": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/custom-media-element/-/custom-media-element-1.3.3.tgz",
-      "integrity": "sha512-5Tenv3iLP8ZiLHcT0qSyfDPrqzkCMxczeLY7cTndbsMF7EkVgL/74a6hxNrn/F6RuD74TLK6R2r0GsmntTTtRg==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/custom-media-element/-/custom-media-element-1.4.5.tgz",
+      "integrity": "sha512-cjrsQufETwxjvwZbYbKBCJNvmQ2++G9AvT45zDi7NXL9k2PdVcs2h0jQz96J6G4TMKRCcEsoJ+QTgQD00Igtjw==",
       "license": "MIT"
     },
     "node_modules/cyclist": {
@@ -8798,9 +8818,9 @@
       }
     },
     "node_modules/hls.js": {
-      "version": "1.5.20",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.5.20.tgz",
-      "integrity": "sha512-uu0VXUK52JhihhnN/MVVo1lvqNNuhoxkonqgO3IpjvQiGpJBdIXMGkofjQb/j9zvV7a1SW8U9g1FslWx/1HOiQ==",
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.13.tgz",
+      "integrity": "sha512-hNEzjZNHf5bFrUNvdS4/1RjIanuJ6szpWNfTaX5I6WfGynWXGT7K/YQLYtemSvFExzeMdgdE4SsyVLJbd5PcZA==",
       "license": "Apache-2.0"
     },
     "node_modules/hoist-non-react-statics": {
@@ -9888,10 +9908,13 @@
       "license": "CC0-1.0"
     },
     "node_modules/media-chrome": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-3.2.5.tgz",
-      "integrity": "sha512-tTsgS7x77Bn4p/wca/Si/7A+Q3z9DzKq0SOkroQvrNMXBVyQasMayDcsKg5Ur5NGsymZfttnJi7tXvVr/tPj8g==",
-      "license": "MIT"
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.15.1.tgz",
+      "integrity": "sha512-Hxqr0qQ67ewmRaLJBqe5ayu53txFX+DODb9xBSHgTbw7j+gITGZ4llbPPEmqMlDnatw7IsF+AUh9rJYbpnn4ZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ce-la-react": "^0.3.0"
+      }
     },
     "node_modules/media-tracks": {
       "version": "0.3.3",
@@ -10202,9 +10225,9 @@
       "license": "MIT"
     },
     "node_modules/mux-embed": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-5.2.1.tgz",
-      "integrity": "sha512-NukHw91xeEVDBeXVDBpi2BvXNix7gSuvdtyvOph5yR/ROn1hHbTlcYWoKQyCyJX9frsF00UROEul+S8wPzU3aQ==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-5.9.0.tgz",
+      "integrity": "sha512-wmunL3uoPhma/tWy8PrDPZkvJpXvSFBwbD3KkC4PG8Ztjfb1X3hRJwGUAQyRz7z99b/ovLm2UTTitrkvStjH4w==",
       "license": "MIT"
     },
     "node_modules/nano-pubsub": {
@@ -11039,6 +11062,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/player.style": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/player.style/-/player.style-0.3.0.tgz",
+      "integrity": "sha512-ny1TbqA2ZsUd6jzN+F034+UMXVK7n5SrwepsrZ2gIqVz00Hn0ohCUbbUdst/2IOFCy0oiTbaOXkSFxRw1RmSlg==",
+      "license": "MIT",
+      "workspaces": [
+        ".",
+        "site",
+        "examples/*",
+        "scripts/*",
+        "themes/*"
+      ],
+      "dependencies": {
+        "media-chrome": "~4.14.0"
+      }
+    },
+    "node_modules/player.style/node_modules/media-chrome": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.14.0.tgz",
+      "integrity": "sha512-IEdFb4blyF15vLvQzLIn6USJBv7Kf2ne+TfLQKBYI5Z0f9VEBVZz5MKy4Uhi0iA9lStl2S9ENIujJRuJIa5OiA==",
+      "license": "MIT",
+      "dependencies": {
+        "ce-la-react": "^0.3.0"
       }
     },
     "node_modules/pluralize-esm": {
@@ -12328,6 +12376,96 @@
         "sanity": "^3.42.0",
         "styled-components": "^5 || ^6"
       }
+    },
+    "node_modules/sanity-plugin-mux-input/node_modules/@mux/mux-player": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-2.9.1.tgz",
+      "integrity": "sha512-TAyoUSPTV0IXWGMOknL6O+IeGSEJ8aS154DzyzqZgdd3zDJHM8JpkyNHgtowatMHT2lB6h+qMtWfp4u3ijpo2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@mux/mux-video": "0.20.2",
+        "@mux/playback-core": "0.25.2",
+        "media-chrome": "~3.2.5"
+      }
+    },
+    "node_modules/sanity-plugin-mux-input/node_modules/@mux/mux-player-react": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-2.9.1.tgz",
+      "integrity": "sha512-1BpMs1J7P+d+/QCf9/mkTk/NPYR6sOskR4Ih0uFZjDAqNUN7/C9Q0FEJ6hF3sFXwAXo50RhnfCzsC5uYx3QHbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mux/mux-player": "2.9.1",
+        "@mux/playback-core": "0.25.2",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18 || ^19",
+        "react": "^17.0.2 || ^18 || ^19",
+        "react-dom": "^17.0.2 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sanity-plugin-mux-input/node_modules/@mux/mux-video": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.20.2.tgz",
+      "integrity": "sha512-CqkK9EZZWdQE4U62JKlmWDskirT+D9C4suh2tSqKb2CA/0S4ybbbrVWcCKF7xfadUacfKO1yPsOKbe46F6phVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mux/playback-core": "0.25.2",
+        "castable-video": "~1.0.9",
+        "custom-media-element": "~1.3.1",
+        "media-tracks": "~0.3.2"
+      }
+    },
+    "node_modules/sanity-plugin-mux-input/node_modules/@mux/playback-core": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.25.2.tgz",
+      "integrity": "sha512-vrBbCgLHwmPpVxF0QGj+sXHUVXSxgDJJhVm8pxPXEkbw0vjPNHTXgAd/Ty6JA0vZ0ZjoQuAa17AxJ+c02JYeWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hls.js": "~1.5.11",
+        "mux-embed": "~5.2.0"
+      }
+    },
+    "node_modules/sanity-plugin-mux-input/node_modules/castable-video": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/castable-video/-/castable-video-1.0.10.tgz",
+      "integrity": "sha512-tJgUv+8/zE191y8EKojvB0eKIyKA9obIttd6Wpdm6x2qBmuwZ7wDgzVCSmf5cN2v9jBiuu0s7O5poz8a8cFX/w==",
+      "license": "MIT",
+      "dependencies": {
+        "custom-media-element": "~1.3.2"
+      }
+    },
+    "node_modules/sanity-plugin-mux-input/node_modules/custom-media-element": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/custom-media-element/-/custom-media-element-1.3.3.tgz",
+      "integrity": "sha512-5Tenv3iLP8ZiLHcT0qSyfDPrqzkCMxczeLY7cTndbsMF7EkVgL/74a6hxNrn/F6RuD74TLK6R2r0GsmntTTtRg==",
+      "license": "MIT"
+    },
+    "node_modules/sanity-plugin-mux-input/node_modules/hls.js": {
+      "version": "1.5.20",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.5.20.tgz",
+      "integrity": "sha512-uu0VXUK52JhihhnN/MVVo1lvqNNuhoxkonqgO3IpjvQiGpJBdIXMGkofjQb/j9zvV7a1SW8U9g1FslWx/1HOiQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/sanity-plugin-mux-input/node_modules/media-chrome": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-3.2.5.tgz",
+      "integrity": "sha512-tTsgS7x77Bn4p/wca/Si/7A+Q3z9DzKq0SOkroQvrNMXBVyQasMayDcsKg5Ur5NGsymZfttnJi7tXvVr/tPj8g==",
+      "license": "MIT"
+    },
+    "node_modules/sanity-plugin-mux-input/node_modules/mux-embed": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-5.2.1.tgz",
+      "integrity": "sha512-NukHw91xeEVDBeXVDBpi2BvXNix7gSuvdtyvOph5yR/ROn1hHbTlcYWoKQyCyJX9frsF00UROEul+S8wPzU3aQ==",
+      "license": "MIT"
     },
     "node_modules/sanity-plugin-mux-input/node_modules/type-fest": {
       "version": "4.35.0",

--- a/example/package.json
+++ b/example/package.json
@@ -13,7 +13,7 @@
     "reset-mux-credentials": "sanity documents delete secrets.mux"
   },
   "dependencies": {
-    "@mux/mux-player-react": "^2.6.0",
+    "@mux/mux-player-react": "^3.8.0",
     "@portabletext/react": "^3.0.18",
     "@sanity/client": "^6.27.2",
     "@sanity/image-url": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.10.0",
       "license": "MIT",
       "dependencies": {
-        "@mux/mux-player-react": "^2.6.0",
+        "@mux/mux-player-react": "^3.8.0",
         "@mux/upchunk": "^3.4.0",
         "@sanity/icons": "^3.0.0",
         "@sanity/incompatible-plugin": "^1.0.4",
@@ -3429,31 +3429,41 @@
         "resolve": "~1.22.2"
       }
     },
-    "node_modules/@mux/mux-player": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-2.9.1.tgz",
-      "integrity": "sha512-TAyoUSPTV0IXWGMOknL6O+IeGSEJ8aS154DzyzqZgdd3zDJHM8JpkyNHgtowatMHT2lB6h+qMtWfp4u3ijpo2A==",
+    "node_modules/@mux/mux-data-google-ima": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@mux/mux-data-google-ima/-/mux-data-google-ima-0.2.8.tgz",
+      "integrity": "sha512-0ZEkHdcZ6bS8QtcjFcoJeZxJTpX7qRIledf4q1trMWPznugvtajCjCM2kieK/pzkZj1JM6liDRFs1PJSfVUs2A==",
       "license": "MIT",
       "dependencies": {
-        "@mux/mux-video": "0.20.2",
-        "@mux/playback-core": "0.25.2",
-        "media-chrome": "~3.2.5"
+        "mux-embed": "5.9.0"
+      }
+    },
+    "node_modules/@mux/mux-player": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-3.8.0.tgz",
+      "integrity": "sha512-2KcJdW4BBX8JDcXpclFKaNBsqpebtaEfTzwm5lPP1Lf6y5OMILvf2tqVCOczurREVFyaEoVD71vL0I5Vvqb1dA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mux/mux-video": "0.27.2",
+        "@mux/playback-core": "0.31.2",
+        "media-chrome": "~4.15.1",
+        "player.style": "^0.3.0"
       }
     },
     "node_modules/@mux/mux-player-react": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-2.9.1.tgz",
-      "integrity": "sha512-1BpMs1J7P+d+/QCf9/mkTk/NPYR6sOskR4Ih0uFZjDAqNUN7/C9Q0FEJ6hF3sFXwAXo50RhnfCzsC5uYx3QHbA==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-3.8.0.tgz",
+      "integrity": "sha512-c9TKtK9nsSpXOuC1LVLmmHA+Zlpcx4mzgGaA7ZlukrGMfoXWvA90ROSVAAjXRA+UKSHdLIbvNofgG3P6rEE/4Q==",
       "license": "MIT",
       "dependencies": {
-        "@mux/mux-player": "2.9.1",
-        "@mux/playback-core": "0.25.2",
-        "prop-types": "^15.7.2"
+        "@mux/mux-player": "3.8.0",
+        "@mux/playback-core": "0.31.2",
+        "prop-types": "^15.8.1"
       },
       "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18 || ^19",
-        "react": "^17.0.2 || ^18 || ^19",
-        "react-dom": "^17.0.2 || ^18 || ^19"
+        "@types/react": "^17.0.0 || ^17.0.0-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0",
+        "react": "^17.0.2 || ^17.0.0-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0",
+        "react-dom": "^17.0.2 || ^17.0.2-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -3465,25 +3475,26 @@
       }
     },
     "node_modules/@mux/mux-video": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.20.2.tgz",
-      "integrity": "sha512-CqkK9EZZWdQE4U62JKlmWDskirT+D9C4suh2tSqKb2CA/0S4ybbbrVWcCKF7xfadUacfKO1yPsOKbe46F6phVQ==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.27.2.tgz",
+      "integrity": "sha512-VAqSw/3kS/qBzjyFSX3wClIX5Kdk6eXXlhxIJRWlClYvUKGm9ruhd7HzkwZVOJguvUh5QbGoiGWBEW2xkNIXzw==",
       "license": "MIT",
       "dependencies": {
-        "@mux/playback-core": "0.25.2",
-        "castable-video": "~1.0.9",
-        "custom-media-element": "~1.3.1",
-        "media-tracks": "~0.3.2"
+        "@mux/mux-data-google-ima": "0.2.8",
+        "@mux/playback-core": "0.31.2",
+        "castable-video": "~1.1.11",
+        "custom-media-element": "~1.4.5",
+        "media-tracks": "~0.3.3"
       }
     },
     "node_modules/@mux/playback-core": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.25.2.tgz",
-      "integrity": "sha512-vrBbCgLHwmPpVxF0QGj+sXHUVXSxgDJJhVm8pxPXEkbw0vjPNHTXgAd/Ty6JA0vZ0ZjoQuAa17AxJ+c02JYeWQ==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.31.2.tgz",
+      "integrity": "sha512-bhOVTGAuKCQuDzNOc3XvDq7vsgqy2DAacLP0WdJciUKjfZhs3oA11NbKG7qAN6akPnZVfgn0Jn/sJN8TRjE30A==",
       "license": "MIT",
       "dependencies": {
-        "hls.js": "~1.5.11",
-        "mux-embed": "~5.2.0"
+        "hls.js": "~1.6.13",
+        "mux-embed": "^5.8.3"
       }
     },
     "node_modules/@mux/upchunk": {
@@ -9188,12 +9199,21 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/castable-video": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/castable-video/-/castable-video-1.0.10.tgz",
-      "integrity": "sha512-tJgUv+8/zE191y8EKojvB0eKIyKA9obIttd6Wpdm6x2qBmuwZ7wDgzVCSmf5cN2v9jBiuu0s7O5poz8a8cFX/w==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/castable-video/-/castable-video-1.1.11.tgz",
+      "integrity": "sha512-LCRTK6oe7SB1SiUQFzZCo6D6gcEzijqBTVIuj3smKpQdesXM18QTbCVqWgh9MfOeQgTx/i9ji5jGcdqNPeWg2g==",
       "license": "MIT",
       "dependencies": {
-        "custom-media-element": "~1.3.2"
+        "custom-media-element": "~1.4.5"
+      }
+    },
+    "node_modules/ce-la-react": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/ce-la-react/-/ce-la-react-0.3.1.tgz",
+      "integrity": "sha512-g0YwpZDPIwTwFumGTzNHcgJA6VhFfFCJkSNdUdC04br2UfU+56JDrJrJva3FZ7MToB4NDHAFBiPE/PZdNl1mQA==",
+      "license": "BSD-3-Clause",
+      "peerDependencies": {
+        "react": ">=17.0.0"
       }
     },
     "node_modules/chalk": {
@@ -10203,9 +10223,9 @@
       "license": "MIT"
     },
     "node_modules/custom-media-element": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/custom-media-element/-/custom-media-element-1.3.3.tgz",
-      "integrity": "sha512-5Tenv3iLP8ZiLHcT0qSyfDPrqzkCMxczeLY7cTndbsMF7EkVgL/74a6hxNrn/F6RuD74TLK6R2r0GsmntTTtRg==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/custom-media-element/-/custom-media-element-1.4.5.tgz",
+      "integrity": "sha512-cjrsQufETwxjvwZbYbKBCJNvmQ2++G9AvT45zDi7NXL9k2PdVcs2h0jQz96J6G4TMKRCcEsoJ+QTgQD00Igtjw==",
       "license": "MIT"
     },
     "node_modules/cyclist": {
@@ -14234,9 +14254,9 @@
       }
     },
     "node_modules/hls.js": {
-      "version": "1.5.20",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.5.20.tgz",
-      "integrity": "sha512-uu0VXUK52JhihhnN/MVVo1lvqNNuhoxkonqgO3IpjvQiGpJBdIXMGkofjQb/j9zvV7a1SW8U9g1FslWx/1HOiQ==",
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.13.tgz",
+      "integrity": "sha512-hNEzjZNHf5bFrUNvdS4/1RjIanuJ6szpWNfTaX5I6WfGynWXGT7K/YQLYtemSvFExzeMdgdE4SsyVLJbd5PcZA==",
       "license": "Apache-2.0"
     },
     "node_modules/hoist-non-react-statics": {
@@ -16727,10 +16747,13 @@
       "license": "CC0-1.0"
     },
     "node_modules/media-chrome": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-3.2.5.tgz",
-      "integrity": "sha512-tTsgS7x77Bn4p/wca/Si/7A+Q3z9DzKq0SOkroQvrNMXBVyQasMayDcsKg5Ur5NGsymZfttnJi7tXvVr/tPj8g==",
-      "license": "MIT"
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.15.1.tgz",
+      "integrity": "sha512-Hxqr0qQ67ewmRaLJBqe5ayu53txFX+DODb9xBSHgTbw7j+gITGZ4llbPPEmqMlDnatw7IsF+AUh9rJYbpnn4ZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ce-la-react": "^0.3.0"
+      }
     },
     "node_modules/media-tracks": {
       "version": "0.3.3",
@@ -17188,9 +17211,9 @@
       "license": "ISC"
     },
     "node_modules/mux-embed": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-5.2.1.tgz",
-      "integrity": "sha512-NukHw91xeEVDBeXVDBpi2BvXNix7gSuvdtyvOph5yR/ROn1hHbTlcYWoKQyCyJX9frsF00UROEul+S8wPzU3aQ==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-5.9.0.tgz",
+      "integrity": "sha512-wmunL3uoPhma/tWy8PrDPZkvJpXvSFBwbD3KkC4PG8Ztjfb1X3hRJwGUAQyRz7z99b/ovLm2UTTitrkvStjH4w==",
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -21476,6 +21499,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/player.style": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/player.style/-/player.style-0.3.0.tgz",
+      "integrity": "sha512-ny1TbqA2ZsUd6jzN+F034+UMXVK7n5SrwepsrZ2gIqVz00Hn0ohCUbbUdst/2IOFCy0oiTbaOXkSFxRw1RmSlg==",
+      "license": "MIT",
+      "workspaces": [
+        ".",
+        "site",
+        "examples/*",
+        "scripts/*",
+        "themes/*"
+      ],
+      "dependencies": {
+        "media-chrome": "~4.14.0"
+      }
+    },
+    "node_modules/player.style/node_modules/media-chrome": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.14.0.tgz",
+      "integrity": "sha512-IEdFb4blyF15vLvQzLIn6USJBv7Kf2ne+TfLQKBYI5Z0f9VEBVZz5MKy4Uhi0iA9lStl2S9ENIujJRuJIa5OiA==",
+      "license": "MIT",
+      "dependencies": {
+        "ce-la-react": "^0.3.0"
       }
     },
     "node_modules/pluralize-esm": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "watch": "pkg-utils watch --strict"
   },
   "dependencies": {
-    "@mux/mux-player-react": "^2.6.0",
+    "@mux/mux-player-react": "^3.8.0",
     "@mux/upchunk": "^3.4.0",
     "@sanity/icons": "^3.0.0",
     "@sanity/incompatible-plugin": "^1.0.4",


### PR DESCRIPTION
### Description

Closes https://github.com/sanity-io/sanity-plugin-mux-input/issues/440

Upgraded the dependency for Mux Player to v3.8.0 to fix an issue that came up with recent Chrome 142 update.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
All references to the Mux player dependency have been upgraded.
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

To test this I first upgraded Chrome to verify I could reproduce the issue. In particular, I used the default Movie asset in Mux Dashboard. 
<img width="1015" height="619" alt="image" src="https://github.com/user-attachments/assets/fb417f94-5c52-4ab4-af40-e3c3d1bf23cc" />

Then, after upgrading the dependency, I could confirm that this error no longer happens.
<img width="1110" height="615" alt="image" src="https://github.com/user-attachments/assets/7063465d-a49e-4404-991b-f00bd6d30e55" />

I also did some smoke testing by using different player features to ensure nothing new was broken. Did the same for Safari.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
