### PR TITLE
fix: use plugin source in example to avoid type mismatches

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -18,7 +18,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "sanity": "^3.74.0",
-        "sanity-plugin-mux-input": "^2.4.1",
+        "sanity-plugin-mux-input": "file:..",
         "styled-components": "^6.1.14"
       },
       "devDependencies": {
@@ -26,6 +26,69 @@
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
         "typescript": "5.7.3"
+      }
+    },
+    "..": {
+      "version": "2.10.0",
+      "license": "MIT",
+      "dependencies": {
+        "@mux/mux-player-react": "^2.6.0",
+        "@mux/upchunk": "^3.4.0",
+        "@sanity/icons": "^3.0.0",
+        "@sanity/incompatible-plugin": "^1.0.4",
+        "@sanity/ui": "^2.1.11",
+        "@sanity/uuid": "^3.0.2",
+        "iso-639-1": "^3.1.2",
+        "jsonwebtoken-esm": "^1.0.5",
+        "lodash": "^4.17.21",
+        "react-rx": "^4.1.5",
+        "rxjs": "^7.8.1",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "suspend-react": "^0.1.3",
+        "swr": "^2.2.5",
+        "type-fest": "^4.18.2",
+        "use-error-boundary": "^2.0.6"
+      },
+      "devDependencies": {
+        "@sanity/client": "^6.28.1",
+        "@sanity/pkg-utils": "^6.13.4",
+        "@sanity/plugin-kit": "4.0.19",
+        "@sanity/semantic-release-preset": "^5.0.0",
+        "@sanity/vision": "^3.77.2",
+        "@types/lodash": "^4.17.15",
+        "@types/react": "^19.0.10",
+        "@types/react-is": "^19.0.0",
+        "@typescript-eslint/eslint-plugin": "^7.18.0",
+        "@typescript-eslint/parser": "^7.18.0",
+        "eslint": "^8.57.1",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-config-react-app": "^7.0.1",
+        "eslint-config-sanity": "^7.1.4",
+        "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-prettier": "^5.2.3",
+        "eslint-plugin-react-hooks": "^5.1.0",
+        "eslint-plugin-simple-import-sort": "^12.1.1",
+        "husky": "^9.0.11",
+        "lint-staged": "^15.2.2",
+        "npm-run-all2": "^5.0.2",
+        "prettier": "^3.5.2",
+        "prettier-plugin-packagejson": "^2.5.9",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "react-is": "^19.0.0",
+        "sanity": "^3.77.2",
+        "semantic-release": "^24.2.3",
+        "styled-components": "^6.1.15",
+        "typescript": "5.7.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18.3 || ^19",
+        "react-is": "^18.3 || ^19",
+        "sanity": "^3.42.0 || ^4.0.0-0",
+        "styled-components": "^5 || ^6"
       }
     },
     "node_modules/@actions/core": {
@@ -2816,28 +2879,6 @@
         "mux-embed": "~5.2.0"
       }
     },
-    "node_modules/@mux/upchunk": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@mux/upchunk/-/upchunk-3.4.0.tgz",
-      "integrity": "sha512-ZaX4u6xRhmgB4UAmw0lvO0LB1LddbRgSILkjRDnk1F4QDtkCOuY9nOh550TNI7uKYcf6HZQax7QXst6EkpjiyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^6.0.2",
-        "xhr": "^2.6.0"
-      }
-    },
-    "node_modules/@mux/upchunk/node_modules/event-target-shim": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
-      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
     "node_modules/@next/env": {
       "version": "14.2.24",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.24.tgz",
@@ -4450,16 +4491,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@sanity/incompatible-plugin": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@sanity/incompatible-plugin/-/incompatible-plugin-1.0.5.tgz",
-      "integrity": "sha512-9JGAacbElUPy9Chghd+sllIiM3jAcraZdD65bWYWUVKkghOsf1L/+jFLz1rcAuvrA9o2s7Y+T75BNcXuLwRcvw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.9 || ^17 || ^18 || ^19",
-        "react-dom": "^16.9 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/@sanity/insert-menu": {
@@ -7552,15 +7583,6 @@
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "license": "ISC"
     },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
@@ -9151,12 +9173,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-function": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
-      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
-      "license": "MIT"
-    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -9358,15 +9374,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
-    },
-    "node_modules/iso-639-1": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/iso-639-1/-/iso-639-1-3.1.5.tgz",
-      "integrity": "sha512-gXkz5+KN7HrG0Q5UGqSMO2qB9AsbEeyLP54kF1YrMsIxmu+g4BdB7rflReZTSTZGpfj8wywu6pfPBCylPIzGQA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0"
-      }
     },
     "node_modules/isobject": {
       "version": "3.0.1",
@@ -9604,15 +9611,6 @@
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsonwebtoken-esm": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken-esm/-/jsonwebtoken-esm-1.0.5.tgz",
-      "integrity": "sha512-CW3CJGtN3nAtkoyV58jl0aOo8VzFv3V2t24ef5OEdULwMGp9pUpnWkCmwxuwo16Tfhoq9cUBFLb3i9P2YlVc4Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.18"
       }
     },
     "node_modules/kind-of": {
@@ -10705,12 +10703,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/parse-headers": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
-      "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA==",
-      "license": "MIT"
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -12297,49 +12289,8 @@
       }
     },
     "node_modules/sanity-plugin-mux-input": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/sanity-plugin-mux-input/-/sanity-plugin-mux-input-2.5.0.tgz",
-      "integrity": "sha512-NJG98wRJzVQbHJxkigxKHbF7uw38plklvjpo2OSsp1xhnFaySBPqaYYgmd8h+KXqDTA8cEUon4zdx3L/RNczVA==",
-      "license": "MIT",
-      "dependencies": {
-        "@mux/mux-player-react": "^2.6.0",
-        "@mux/upchunk": "^3.4.0",
-        "@sanity/icons": "^3.0.0",
-        "@sanity/incompatible-plugin": "^1.0.4",
-        "@sanity/ui": "^2.1.11",
-        "@sanity/uuid": "^3.0.2",
-        "iso-639-1": "^3.1.2",
-        "jsonwebtoken-esm": "^1.0.5",
-        "lodash": "^4.17.21",
-        "react-rx": "^4.1.5",
-        "rxjs": "^7.8.1",
-        "scroll-into-view-if-needed": "^3.1.0",
-        "suspend-react": "^0.1.3",
-        "swr": "^2.2.5",
-        "type-fest": "^4.18.2",
-        "use-error-boundary": "^2.0.6"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^18",
-        "react-is": "^18",
-        "sanity": "^3.42.0",
-        "styled-components": "^5 || ^6"
-      }
-    },
-    "node_modules/sanity-plugin-mux-input/node_modules/type-fest": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.35.0.tgz",
-      "integrity": "sha512-2/AwEFQDFEy30iOLjrvHDIH7e4HEWH+f1Yl1bI5XMqzuoCUqwYCdxachgsgv0og/JdVZUhbfjcJAoHj5L1753A==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+      "resolved": "..",
+      "link": true
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -12965,19 +12916,6 @@
         "react": ">=17.0"
       }
     },
-    "node_modules/swr": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.1.tgz",
-      "integrity": "sha512-ALcpdX8Q2WGkuSKrxb1SSGCzoRb3xfkq0SH+AhtF9OXIWIXGSA+uJzGT682UJjqSTC2uN0myJJikFz43ApUPAw==",
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.3",
-        "use-sync-external-store": "^1.4.0"
-      },
-      "peerDependencies": {
-        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -13561,21 +13499,6 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^18.3 || ^19.0.0-0"
-      }
-    },
-    "node_modules/use-error-boundary": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/use-error-boundary/-/use-error-boundary-2.0.6.tgz",
-      "integrity": "sha512-AWCVKSAanLe6R/on/ZkHYtGKfXs8BQX6z/TUGYqtvkajLqQyrGKJJscbahtq8OyN8L3LqTRjJWx4gCOLmfIObw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
       }
     },
     "node_modules/use-hot-module-reload": {
@@ -14432,18 +14355,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/xhr": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
-      "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
-      "license": "MIT",
-      "dependencies": {
-        "global": "~4.4.0",
-        "is-function": "^1.0.1",
-        "parse-headers": "^2.0.0",
-        "xtend": "^4.0.0"
       }
     },
     "node_modules/xml-name-validator": {

--- a/example/package.json
+++ b/example/package.json
@@ -23,7 +23,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "sanity": "^3.74.0",
-    "sanity-plugin-mux-input": "^2.4.1",
+    "sanity-plugin-mux-input": "file:..",
     "styled-components": "^6.1.14"
   },
   "devDependencies": {


### PR DESCRIPTION
### TL;DR

Updated the example project to use the local plugin version instead of the published one.

### What changed?

Modified the example project's package.json and package-lock.json to use the local plugin version (`file:..`) instead of the published version (`^2.4.1`). This links the example project to the local development version of the plugin.

### How to test?

1. Run `npm install` in the example directory
2. Start the example project with `npm run dev`
3. Verify that changes made to the plugin code are immediately reflected in the example project

### Why make this change?

This change enables easier development and testing of the plugin by allowing developers to see their changes immediately reflected in the example project without having to publish new versions. It creates a direct link between the plugin source code and the example implementation, streamlining the development workflow.