### PR TITLE
fix: use Suspense, so signed videos always load

### DIFF
--- a/src/_exports/index.ts
+++ b/src/_exports/index.ts
@@ -6,6 +6,12 @@ import {muxVideoSchema, schemaTypes} from '../schema'
 import type {PluginConfig, StaticRenditionResolution} from '../util/types'
 export type {VideoAssetDocument} from '../util/types'
 
+// Preload the JWT signing library to avoid race condition on first render
+// This ensures the library is available when generateJwt() is called
+import('jsonwebtoken-esm/sign').catch(() => {
+  // Ignore errors - library will be loaded via suspend() if this fails
+})
+
 export const defaultConfig: PluginConfig = {
   static_renditions: [],
   mp4_support: 'none',

--- a/src/components/EditThumbnailDialog.tsx
+++ b/src/components/EditThumbnailDialog.tsx
@@ -1,5 +1,5 @@
 import {Button, Dialog, Flex, Stack, Text, TextInput} from '@sanity/ui'
-import React, {useId, useMemo, useState} from 'react'
+import React, {Suspense, useId, useMemo, useState} from 'react'
 import {getDevicePixelRatio} from 'use-device-pixel-ratio'
 
 import {useDialogStateContext} from '../context/DialogStateContext'
@@ -11,6 +11,7 @@ import {
 } from '../util/formatSeconds'
 import type {VideoAssetDocument} from '../util/types'
 import VideoThumbnail from './VideoThumbnail'
+import VideoThumbnailFallback from './VideoThumbnailFallback'
 
 export interface Props {
   asset: VideoAssetDocument
@@ -87,13 +88,17 @@ export default function EditThumbnailDialog({asset, currentTime = 0}: Props) {
           <Text size={1} weight="semibold">
             Current:
           </Text>
-          <VideoThumbnail asset={asset} width={width} staticImage />
+          <Suspense fallback={<VideoThumbnailFallback width={width} />}>
+            <VideoThumbnail asset={asset} width={width} staticImage />
+          </Suspense>
         </Stack>
         <Stack space={2}>
           <Text size={1} weight="semibold">
             New:
           </Text>
-          <VideoThumbnail asset={assetWithNewThumbnail} width={width} staticImage />
+          <Suspense fallback={<VideoThumbnailFallback width={width} />}>
+            <VideoThumbnail asset={assetWithNewThumbnail} width={width} staticImage />
+          </Suspense>
         </Stack>
 
         <Stack space={2}>

--- a/src/components/ImportVideosFromMux.tsx
+++ b/src/components/ImportVideosFromMux.tsx
@@ -18,6 +18,7 @@ import {
   Stack,
   Text,
 } from '@sanity/ui'
+import {Suspense} from 'react'
 import {truncateString, useFormattedDuration} from 'sanity'
 import {styled} from 'styled-components'
 
@@ -25,6 +26,7 @@ import useImportMuxAssets from '../hooks/useImportMuxAssets'
 import {DIALOGS_Z_INDEX} from '../util/constants'
 import type {MuxAsset} from '../util/types'
 import VideoThumbnail from './VideoThumbnail'
+import VideoThumbnailFallback from './VideoThumbnailFallback'
 
 const MissingAssetCheckbox = styled(Checkbox)`
   position: static !important;
@@ -68,15 +70,17 @@ function MissingAsset({
           }}
           aria-label={selected ? `Import video ${asset.id}` : `Skip import of video ${asset.id}`}
         />
-        <VideoThumbnail
-          asset={{
-            assetId: asset.id,
-            data: asset,
-            filename: asset.id,
-            playbackId: asset.playback_ids.find((p) => p.id)?.id,
-          }}
-          width={150}
-        />
+        <Suspense fallback={<VideoThumbnailFallback width={150} />}>
+          <VideoThumbnail
+            asset={{
+              assetId: asset.id,
+              data: asset,
+              filename: asset.id,
+              playbackId: asset.playback_ids.find((p) => p.id)?.id,
+            }}
+            width={150}
+          />
+        </Suspense>
         <Stack space={2}>
           <Flex align="center" gap={1}>
             <Code size={2}>{truncateString(asset.id, 15)}</Code>{' '}

--- a/src/components/Player.tsx
+++ b/src/components/Player.tsx
@@ -1,11 +1,19 @@
 import {Card, Text} from '@sanity/ui'
-import React, {useEffect, useMemo, useRef} from 'react'
+import React, {Suspense, useEffect, useMemo, useRef} from 'react'
 
 import {useCancelUpload} from '../hooks/useCancelUpload'
 import type {MuxInputProps, PluginConfig, VideoAssetDocument} from '../util/types'
 import {TopControls} from './Player.styled'
 import {UploadProgress} from './UploadProgress'
 import VideoPlayer from './VideoPlayer'
+
+function PlayerFallback() {
+  return (
+    <Card padding={4} radius={2} tone="transparent">
+      <Text align="center" muted>Loading video player...</Text>
+    </Card>
+  )
+}
 
 interface Props extends Pick<MuxInputProps, 'onChange' | 'readOnly'> {
   buttons?: React.ReactNode
@@ -92,25 +100,27 @@ const Player = ({asset, buttons, readOnly, onChange, config}: Props) => {
   }
 
   return (
-    <VideoPlayer asset={asset} hlsConfig={config?.hlsConfig}>
-      {buttons && <TopControls slot="top-chrome">{buttons}</TopControls>}
-      {isPreparingStaticRenditions && (
-        <Card
-          padding={2}
-          radius={1}
-          style={{
-            background: 'var(--card-fg-color)',
-            position: 'absolute',
-            top: '0.5em',
-            left: '0.5em',
-          }}
-        >
-          <Text size={1} style={{color: 'var(--card-bg-color)'}}>
-            MUX is preparing static renditions, please stand by
-          </Text>
+    <Suspense fallback={<PlayerFallback />}>
+      <VideoPlayer asset={asset} hlsConfig={config?.hlsConfig}>
+        {buttons && <TopControls slot="top-chrome">{buttons}</TopControls>}
+        {isPreparingStaticRenditions && (
+          <Card
+            padding={2}
+            radius={1}
+            style={{
+              background: 'var(--card-fg-color)',
+              position: 'absolute',
+              top: '0.5em',
+              left: '0.5em',
+            }}
+          >
+            <Text size={1} style={{color: 'var(--card-bg-color)'}}>
+              MUX is preparing static renditions, please stand by
+            </Text>
         </Card>
       )}
-    </VideoPlayer>
+      </VideoPlayer>
+    </Suspense>
   )
 }
 

--- a/src/components/VideoInBrowser.tsx
+++ b/src/components/VideoInBrowser.tsx
@@ -1,6 +1,6 @@
 import {CheckmarkIcon, EditIcon, LockIcon, PlayIcon} from '@sanity/icons'
 import {Button, Card, Stack, Text, Tooltip} from '@sanity/ui'
-import React, {useState} from 'react'
+import React, {Suspense, useState} from 'react'
 import {styled} from 'styled-components'
 
 import {THUMBNAIL_ASPECT_RATIO} from '../util/constants'
@@ -11,6 +11,7 @@ import {AudioIcon} from './icons/Audio'
 import VideoMetadata from './VideoMetadata'
 import VideoPlayer, {assetIsAudio} from './VideoPlayer'
 import VideoThumbnail from './VideoThumbnail'
+import VideoThumbnailFallback from './VideoThumbnailFallback'
 
 const PlayButton = styled.button`
   display: block;
@@ -156,7 +157,9 @@ export default function VideoInBrowser({
                 <AudioIcon width="3em" height="3em" />
               </div>
             ) : (
-              <VideoThumbnail asset={asset} />
+              <Suspense fallback={<VideoThumbnailFallback />}>
+                <VideoThumbnail asset={asset} />
+              </Suspense>
             )}
           </PlayButton>
         )}

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -46,6 +46,10 @@ export default function VideoPlayer({
       return {error: new TypeError('Asset has no playback ID')}
       // eslint-disable-next-line @typescript-eslint/no-shadow
     } catch (error) {
+      // Re-throw if it's a Promise (Suspense mechanism) - don't catch it!
+      if (error && typeof error === 'object' && 'then' in error && typeof error.then === 'function') {
+        throw error
+      }
       return {error}
     }
   }, [asset, client, thumbnailWidth])

--- a/src/components/VideoThumbnail.tsx
+++ b/src/components/VideoThumbnail.tsx
@@ -50,7 +50,12 @@ export default function VideoThumbnail({
       else thumbnail = getAnimatedPosterSrc({asset, client, width: posterWidth})
 
       return thumbnail
-    } catch {
+    } catch (error) {
+      // Re-throw if it's a Promise (Suspense mechanism) - don't catch it!
+      if (error && typeof error === 'object' && 'then' in error && typeof error.then === 'function') {
+        throw error
+      }
+      // Handle actual errors
       if (status !== 'error') setStatus('error')
       return undefined
     }

--- a/src/components/VideoThumbnailFallback.tsx
+++ b/src/components/VideoThumbnailFallback.tsx
@@ -1,0 +1,31 @@
+import {Box, Card, Spinner} from '@sanity/ui'
+
+import {THUMBNAIL_ASPECT_RATIO} from '../util/constants'
+
+export default function VideoThumbnailFallback({width}: {width?: number}) {
+  return (
+    <Card
+      style={{
+        aspectRatio: THUMBNAIL_ASPECT_RATIO,
+        position: 'relative',
+        maxWidth: width ? `${width}px` : undefined,
+        width: '100%',
+        flex: 1,
+      }}
+      border
+      radius={2}
+      tone="transparent"
+    >
+      <Box
+        style={{
+          position: 'absolute',
+          left: '50%',
+          top: '50%',
+          transform: 'translate(-50%, -50%)',
+        }}
+      >
+        <Spinner />
+      </Box>
+    </Card>
+  )
+}

--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -1,5 +1,8 @@
+import {Suspense} from 'react'
+
 import Input from './components/Input'
 import VideoThumbnail from './components/VideoThumbnail'
+import VideoThumbnailFallback from './components/VideoThumbnailFallback'
 import type {MuxInputProps, PluginConfig, VideoAssetDocument} from './util/types'
 
 export function muxVideoCustomRendering(config: PluginConfig) {
@@ -23,7 +26,7 @@ export function muxVideoCustomRendering(config: PluginConfig) {
         return {
           title: filename || playbackId || '',
           subtitle: status ? `status: ${status}` : null,
-          media: asset.playbackId ? <VideoThumbnail asset={asset} width={64} /> : null,
+          media: asset.playbackId ? <Suspense fallback={<VideoThumbnailFallback width={64} />}><VideoThumbnail asset={asset} width={64} /></Suspense> : null,
         }
       },
     },


### PR DESCRIPTION
### Description

Video thumbnails and players fail to load on hard reload with signed URLs. This occurs when using `defaultSigned: true` and `defaultPublic: false` in the plugin config. In this scenario, only signed videos are uploaded and the error occurs.

In my testing, thumbnails and video players would fail to load on the initial page load or after reloading the page. Users see "Failed loading thumbnail" errors and broken video previews. The issue resolves itself after clicking "Resync Metadata" or after interacting with any video (as in, the second interaction with Mux, as the first interaction sends a network request to sign-XXXXXXX.js). However, they break again on the next hard reload.

The same issues occur on localhost and on the hosted sanity studio project.

Root Cause: The plugin uses React Suspense to lazy-load the JWT signing library that's needed to generate signed URLs for video playback. On initial page load, this library hasn't been loaded yet, so when components try to generate signed URLs, Suspense throws a Promise. Several components had try-catch blocks that were catching these Promises before Suspense could handle them properly. This caused the signed URL generation to silently fail, resulting in broken thumbnails and video players.

### What to review

This PR does the following:

1. Re-throw Suspense Promises: Updated all try-catch blocks to detect when a Promise is thrown (the Suspense mechanism) and re-throw it instead of catching it as an error.
2. Add Suspense Boundaries: Wrapped all VideoThumbnail and VideoPlayer usages in `<Suspense>` tags with proper fallback components that match the final rendering size and show loading spinners.
3. Preload JWT Library: Added code to preload the JWT signing library, reducing the likelihood of race conditions.
4. Better Loading States: Created a <VideoThumbnailFallback> component that maintains the correct aspect ratio and styling while showing a spinner during loading, preventing layout shifts.

One bonus of this method is that thumbnails lazy load because of Suspense, which improves performance when loading all Videos in the grid.

### Testing

After this fix, signed videos now load correctly on hard refresh without requiring manual intervention. The loading experience is smooth with proper spinners and no layout shifts.

I have tested manually both videos that are signed and not signed to ensure it works properly. You can test the changes by uploading videos that are only signed.
